### PR TITLE
Fixes missing Netlify Host check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,16 +21,16 @@ const CLOUDINARY_ASSET_DIRECTORIES = [
 
 const _cloudinaryAssets = {};
 
+const isProduction = process.env.CONTEXT === 'production';
+const host = isProduction ? process.env.NETLIFY_HOST : process.env.DEPLOY_PRIME_URL;
+
+console.log(`[Cloudinary] Using host: ${host}`);
+
 module.exports = {
   async onBuild({ netlifyConfig, constants, inputs, utils }) {
     console.log('[Cloudinary] Creating redirects...');
 
     const { PUBLISH_DIR } = constants;
-
-    const isProduction = process.env.CONTEXT === 'production';
-    const host = isProduction ? process.env.NETLIFY_HOST : process.env.DEPLOY_PRIME_URL;
-
-    console.log(`[Cloudinary] Using host: ${host}`);
 
     const {
       deliveryType,
@@ -155,8 +155,6 @@ module.exports = {
   async onPostBuild({ constants, inputs, utils }) {
     console.log('[Cloudinary] Replacing on-page images with Cloudinary URLs...');
 
-    const host = process.env.DEPLOY_PRIME_URL || process.env.NETLIFY_HOST;
-
     if ( !host ) {
       console.warn(`[Cloudinary] ${ERROR_NETLIFY_HOST_UNKNOWN}`);
       console.log(`[Cloudinary] ${ERROR_NETLIFY_HOST_CLI_SUPPORT}`);
@@ -166,7 +164,6 @@ module.exports = {
     const { PUBLISH_DIR } = constants;
     const {
       deliveryType,
-      loadingStrategy,
       uploadPreset,
       folder = process.env.SITE_NAME
     } = inputs;


### PR DESCRIPTION
# Description

The NETLIFY_HOST as fixed in #47 only captured 1 instance where it was used in 2 different locations.

This fixes the second location

## Issue Ticket Number

<!-- Specifiy which issue this fixes by referencing the issue number (`#11`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/netlify-plugin-cloudinary/issues/1 -->

Fixes #45 

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/netlify-plugin-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/netlify-plugin-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
